### PR TITLE
Fix issue #4 where strings with a length divisible by four are parsed…

### DIFF
--- a/libofqf/qoscserver.cpp
+++ b/libofqf/qoscserver.cpp
@@ -87,7 +87,8 @@ void QOscServer::readyRead() {
 					if ( type == 's' ) {
 						QString s = toString( tmp );
 						value = s;
-						i += s.size();
+						// string size plus one for the null terminator
+						i += s.size() + 1;
 					}
 					if ( type == 'i' ) {
 						value = toInt32( tmp );


### PR DESCRIPTION
… in a way that can prevent subsequent string arguments being correctly parsed.
